### PR TITLE
Turn "/bin/env" into more portable "/usr/bin/env"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ piped to sh for buttons.
 ### Example
 
 ````sh
-#!/bin/env sh
+#!/bin/sh
 
 # Optional env variable used by genbar to prepend to the path
 export TENDERBLOCKS="path/to/bartender/block"

--- a/block/i3window
+++ b/block/i3window
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import i3ipc
 import re

--- a/block/i3ws
+++ b/block/i3ws
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
 import i3ipc

--- a/genbar
+++ b/genbar
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 """Generate a bar from stdin
 


### PR DESCRIPTION
My MX Linux (Debian/Devuan) system has `env` inside `/usr/bin`.
I believe there is no real need to call this binary by its absolute path, anyway.